### PR TITLE
Keyword as name

### DIFF
--- a/lib/MarpaX/Languages/Lua/Parser.pm
+++ b/lib/MarpaX/Languages/Lua/Parser.pm
@@ -787,47 +787,26 @@ lexeme default = latm => 1 action => [name,values]
 <field> ::= <Name> '=' <exp>
 <field> ::= <exp>
 
-:lexeme ~ <keyword and> priority => 1
 <keyword and> ~ 'and'
-:lexeme ~ <keyword break> priority => 1
 <keyword break> ~ 'break'
-:lexeme ~ <keyword do> priority => 1
 <keyword do> ~ 'do'
-:lexeme ~ <keyword else> priority => 1
 <keyword else> ~ 'else'
-:lexeme ~ <keyword elseif> priority => 1
 <keyword elseif> ~ 'elseif'
-:lexeme ~ <keyword end> priority => 1
 <keyword end> ~ 'end'
-:lexeme ~ <keyword false> priority => 1
 <keyword false> ~ 'false'
-:lexeme ~ <keyword for> priority => 1
 <keyword for> ~ 'for'
-:lexeme ~ <keyword function> priority => 1
 <keyword function> ~ 'function'
-:lexeme ~ <keyword if> priority => 1
 <keyword if> ~ 'if'
-:lexeme ~ <keyword in> priority => 1
 <keyword in> ~ 'in'
-:lexeme ~ <keyword local> priority => 1
 <keyword local> ~ 'local'
-:lexeme ~ <keyword nil> priority => 1
 <keyword nil> ~ 'nil'
-:lexeme ~ <keyword not> priority => 1
 <keyword not> ~ 'not'
-:lexeme ~ <keyword or> priority => 1
 <keyword or> ~ 'or'
-:lexeme ~ <keyword repeat> priority => 1
 <keyword repeat> ~ 'repeat'
-:lexeme ~ <keyword return> priority => 1
 <keyword return> ~ 'return'
-:lexeme ~ <keyword then> priority => 1
 <keyword then> ~ 'then'
-:lexeme ~ <keyword true> priority => 1
 <keyword true> ~ 'true'
-:lexeme ~ <keyword until> priority => 1
 <keyword until> ~ 'until'
-:lexeme ~ <keyword while> priority => 1
 <keyword while> ~ 'while'
 
 # multiline comments are discarded.  The lexer only looks for

--- a/lib/MarpaX/Languages/Lua/Parser.pm
+++ b/lib/MarpaX/Languages/Lua/Parser.pm
@@ -17,7 +17,7 @@ use Moo;
 
 use Path::Tiny; # For path().
 
-use Types::Standard qw/Any ArrayRef Bool Str/;
+use Types::Standard qw/Any ArrayRef HashRef Bool Str/;
 
 has attributes =>
 (
@@ -113,6 +113,21 @@ has value =>
 	is       => 'rw',
 	isa      => Any,
 	required => 0,
+);
+
+has keywords =>
+(
+    default  => sub{return {
+                    map { $_ => 1 } qw{
+                        and       break     do        else      elseif
+                        end       false     for       function  if
+                        in        local     nil       not       or
+                        repeat    return    then      true      until     while
+                    }
+                }},
+    is       => 'ro',
+    isa      => Any,
+    required => 0,
 );
 
 our $VERSION = '1.00';

--- a/lua.sources/keyword_as_identifier.lua
+++ b/lua.sources/keyword_as_identifier.lua
@@ -1,0 +1,7 @@
+function and(a, b)
+  return a and b
+end
+
+function or(a, b)
+  return a or b
+end

--- a/t/keyword_as_identifier.t
+++ b/t/keyword_as_identifier.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use File::Spec;
+use File::Temp;
+
+use Test::More;
+
+BEGIN {use_ok('MarpaX::Languages::Lua::Parser'); }
+
+my($lua_sources_dir) = 'lua.sources';
+$lua_sources_dir = qq{../$lua_sources_dir} unless $ENV{HARNESS_ACTIVE};
+
+my($parser)             = MarpaX::Languages::Lua::Parser -> new
+(
+    input_file_name  => "$lua_sources_dir/keyword_as_identifier.lua",
+    logger           => '',
+);
+
+eval { $parser -> run };
+like $@, qr/keyword .*? used as <name>/, "keywords are reserved and cannot be used as names";
+
+done_testing;


### PR DESCRIPTION
This enforces the following from Lua manual:

> The following keywords are reserved and cannot be used as names:
> 
> ```
>      and       break     do        else      elseif
>      end       false     for       function  if
>      in        local     nil       not       or
>      repeat    return    then      true      until     while
> ```

from http://www.lua.org/manual/5.1/manual.html#2.1
